### PR TITLE
chore(routing): replace angular-ui-router by @uirouter/angularjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@uirouter/angularjs": "^1.0.3",
     "angular": "^1.6.4",
     "angular-ui-router": "^1.0.0-rc.1",
     "babel-polyfill": "^6.23.0",

--- a/src/nso/presenter/angular/app-routing.module.ts
+++ b/src/nso/presenter/angular/app-routing.module.ts
@@ -1,10 +1,10 @@
 //
 
-import { module as ngModule } from "angular";
 import AngularUiRouterModule, {
   StateProvider,
   UrlRouter,
-} from "angular-ui-router";
+} from "@uirouter/angularjs";
+import { module as ngModule } from "angular";
 
 //
 

--- a/src/nso/presenter/angular/explore/explore-routing.module.ts
+++ b/src/nso/presenter/angular/explore/explore-routing.module.ts
@@ -1,11 +1,11 @@
 //
 
-import { module as ngModule } from "angular";
 import AngularUiRouterModule, {
   StateProvider,
   Transition,
   UrlRouter,
-} from "angular-ui-router";
+} from "@uirouter/angularjs";
+import { module as ngModule } from "angular";
 
 import { fetchPackageInfosAsync } from "nso/dal";
 import {

--- a/src/nso/presenter/angular/explore/explore.controller.spec.ts
+++ b/src/nso/presenter/angular/explore/explore.controller.spec.ts
@@ -3,7 +3,7 @@
 import {
   StateService,
   Transition,
-} from "angular-ui-router";
+} from "@uirouter/angularjs";
 import { test } from "ava";
 import { stub } from "sinon";
 

--- a/src/nso/presenter/angular/explore/explore.controller.ts
+++ b/src/nso/presenter/angular/explore/explore.controller.ts
@@ -4,7 +4,7 @@ import {
   Ng1Controller,
   StateService,
   Transition,
-} from "angular-ui-router";
+} from "@uirouter/angularjs";
 
 import { IExploreRoutingParams } from "./explore-routing.interface";
 


### PR DESCRIPTION
When installing the project npm warns with : 

```
WARNING! this npm package "angular-ui-router" has been renamed to "@uirouter/angularjs".  Please update your package.json
```

See https://ui-router.github.io/blog/uirouter-scoped-packages/ for details.